### PR TITLE
Fix - external link handling

### DIFF
--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -7,6 +7,7 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		503BA26D2A2C93C70052516C /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503BA26C2A2C93C70052516C /* SafariView.swift */; };
 		630737892A1CD1E900039852 /* String - Escape Special Characters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630737882A1CD1E900039852 /* String - Escape Special Characters.swift */; };
 		6307378B2A1CE2B300039852 /* Rate Post or Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6307378A2A1CE2B300039852 /* Rate Post or Comment.swift */; };
 		6307378D2A1CEB7C00039852 /* My Vote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6307378C2A1CEB7C00039852 /* My Vote.swift */; };
@@ -132,6 +133,7 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		503BA26C2A2C93C70052516C /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
 		630737882A1CD1E900039852 /* String - Escape Special Characters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String - Escape Special Characters.swift"; sourceTree = "<group>"; };
 		6307378A2A1CE2B300039852 /* Rate Post or Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rate Post or Comment.swift"; sourceTree = "<group>"; };
 		6307378C2A1CEB7C00039852 /* My Vote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "My Vote.swift"; sourceTree = "<group>"; };
@@ -687,6 +689,7 @@
 				6386E03F2A045723006B3C1D /* Website Icon Complex.swift */,
 				63D24EDD2A169F2A005CCA81 /* Markdown View.swift */,
 				6374570F2A18CB6600B69C03 /* Custom Text Field.swift */,
+				503BA26C2A2C93C70052516C /* SafariView.swift */,
 			);
 			path = Shared;
 			sourceTree = "<group>";
@@ -968,6 +971,7 @@
 				6318EDC927EE4E1C00BFCAE8 /* Comment.swift in Sources */,
 				6322A5D227F88CFD00135D4F /* Time Parser.swift in Sources */,
 				63CE4E712A06B21B00405271 /* Avatar View.swift in Sources */,
+				503BA26D2A2C93C70052516C /* SafariView.swift in Sources */,
 				6386E0402A045723006B3C1D /* Website Icon Complex.swift in Sources */,
 				63F0C7BD2A058CD200A18C5D /* Check if Endpoint Exists.swift in Sources */,
 				6363D5C727EE196700E34822 /* ContentView.swift in Sources */,

--- a/Mlem.xcodeproj/project.pbxproj
+++ b/Mlem.xcodeproj/project.pbxproj
@@ -8,6 +8,7 @@
 
 /* Begin PBXBuildFile section */
 		503BA26D2A2C93C70052516C /* SafariView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503BA26C2A2C93C70052516C /* SafariView.swift */; };
+		503BA26F2A2C94540052516C /* URL+Identifiable.swift in Sources */ = {isa = PBXBuildFile; fileRef = 503BA26E2A2C94540052516C /* URL+Identifiable.swift */; };
 		630737892A1CD1E900039852 /* String - Escape Special Characters.swift in Sources */ = {isa = PBXBuildFile; fileRef = 630737882A1CD1E900039852 /* String - Escape Special Characters.swift */; };
 		6307378B2A1CE2B300039852 /* Rate Post or Comment.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6307378A2A1CE2B300039852 /* Rate Post or Comment.swift */; };
 		6307378D2A1CEB7C00039852 /* My Vote.swift in Sources */ = {isa = PBXBuildFile; fileRef = 6307378C2A1CEB7C00039852 /* My Vote.swift */; };
@@ -134,6 +135,7 @@
 
 /* Begin PBXFileReference section */
 		503BA26C2A2C93C70052516C /* SafariView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SafariView.swift; sourceTree = "<group>"; };
+		503BA26E2A2C94540052516C /* URL+Identifiable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "URL+Identifiable.swift"; sourceTree = "<group>"; };
 		630737882A1CD1E900039852 /* String - Escape Special Characters.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "String - Escape Special Characters.swift"; sourceTree = "<group>"; };
 		6307378A2A1CE2B300039852 /* Rate Post or Comment.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Rate Post or Comment.swift"; sourceTree = "<group>"; };
 		6307378C2A1CEB7C00039852 /* My Vote.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "My Vote.swift"; sourceTree = "<group>"; };
@@ -421,6 +423,7 @@
 				63344C6D2A097FA1001BC616 /* View - Hide View.swift */,
 				63D24ED82A169A5F005CCA81 /* UIApplication - First Key Window.swift */,
 				630737882A1CD1E900039852 /* String - Escape Special Characters.swift */,
+				503BA26E2A2C94540052516C /* URL+Identifiable.swift */,
 			);
 			path = Extensions;
 			sourceTree = "<group>";
@@ -981,6 +984,7 @@
 				63E5D3872A138AA500EC1FBD /* Community Search Field.swift in Sources */,
 				6322A5CB27F77A4D00135D4F /* Loading View.swift in Sources */,
 				63E5D3982A13DCFB00EC1FBD /* Remove Community from Favorites.swift in Sources */,
+				503BA26F2A2C94540052516C /* URL+Identifiable.swift in Sources */,
 				63ABCE0E27F894060047A7D0 /* User View.swift in Sources */,
 				6318DE5427FB958800CC2AD6 /* Stickied Tag.swift in Sources */,
 				6386E03A2A0455BC006B3C1D /* String - Contains Elements From Array.swift in Sources */,

--- a/Mlem/App Constants.swift
+++ b/Mlem/App Constants.swift
@@ -6,8 +6,8 @@
 //
 
 import Foundation
-import SafariServices
 import KeychainAccess
+import UIKit
 
 struct AppConstants
 {
@@ -19,16 +19,6 @@ struct AppConstants
     
     // MARK: - Keychain
     static let keychain: Keychain = Keychain(service: "com.davidbures.Mlem-keychain")
-    
-    // MARK: - In-app Safari
-    static let inAppSafariConfiguration: SFSafariViewController.Configuration =
-    {
-        let configuration = SFSafariViewController.Configuration()
-        configuration.barCollapsingEnabled = true
-        configuration.entersReaderIfAvailable = false
-        
-        return configuration
-    }()
     
     // MARK: - Files
     private static let applicationSupportDirectoryPath: URL = try! FileManager.default.url(for: .applicationSupportDirectory, in: .userDomainMask, appropriateFor: nil, create: true)

--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -7,8 +7,10 @@
 
 import SwiftUI
 
-struct ContentView: View
-{    
+struct ContentView: View {
+    
+    @State private var urlToDisplay: URL?
+    
     var body: some View
     {
         TabView
@@ -29,5 +31,13 @@ struct ContentView: View
         {
             AppConstants.keychain["test"] = "I-am-a-saved-thing"
         }
+        .environment(\.openURL, OpenURLAction(handler: handleURL))
+        .sheet(item: $urlToDisplay) { SafariView(url: $0) }
+    }
+    
+    private func handleURL(_ url: URL) -> OpenURLAction.Result {
+        #warning("TODO: consider how we might deep link within the application for urls such as '/c/<community_name>' and '/post/<post_id>'")
+        urlToDisplay = url
+        return .handled
     }
 }

--- a/Mlem/Extensions/URL+Identifiable.swift
+++ b/Mlem/Extensions/URL+Identifiable.swift
@@ -1,0 +1,12 @@
+//
+//  URL+Identifiable.swift
+//  Mlem
+//
+//  Created by Nicholas Lawson on 04/06/2023.
+//
+
+import Foundation
+
+extension URL: Identifiable {
+    public var id: URL { absoluteURL }
+}

--- a/Mlem/Views/Shared/Markdown View.swift
+++ b/Mlem/Views/Shared/Markdown View.swift
@@ -6,7 +6,6 @@
 //
 
 import MarkdownUI
-import SafariServices
 import SwiftUI
 
 extension Theme
@@ -235,7 +234,6 @@ private extension Color
 
 struct MarkdownView: View
 {
-    @Environment(\.openURL) private var openURL
 
     @State var text: String
 
@@ -244,13 +242,5 @@ struct MarkdownView: View
         Markdown(text)
             .markdownTheme(.mlem)
             .background(Color.systemBackground)
-            .environment(\.openURL, OpenURLAction
-            { interceptedURL in
-                let safariViewController = SFSafariViewController(url: interceptedURL, configuration: AppConstants.inAppSafariConfiguration)
-
-                UIApplication.shared.firstKeyWindow?.rootViewController?.present(safariViewController, animated: true)
-
-                return .handled
-            })
     }
 }

--- a/Mlem/Views/Shared/SafariView.swift
+++ b/Mlem/Views/Shared/SafariView.swift
@@ -1,0 +1,43 @@
+//
+//  SafariView.swift
+//  Mlem
+//
+//  Created by Nicholas Lawson on 04/06/2023.
+//
+
+import SafariServices
+import SwiftUI
+
+extension SFSafariViewController.Configuration {
+    /// The default settings used in this application
+    static var `default`: Self {
+        let configuration = Self.init()
+        configuration.entersReaderIfAvailable = false
+        return configuration
+    }
+}
+
+/// A wrapper to allow use of `SFSafariViewController` in `SwiftUI` contexts
+struct SafariView: UIViewControllerRepresentable {
+    
+    let url: URL
+    let configuration: SFSafariViewController.Configuration
+    
+    init(url: URL, configuration: SFSafariViewController.Configuration = .default) {
+        self.url = url
+        self.configuration = configuration
+    }
+
+    func makeUIViewController(
+        context: UIViewControllerRepresentableContext<SafariView>
+    ) -> SFSafariViewController {
+        SFSafariViewController(url: url)
+    }
+
+    func updateUIViewController(
+        _ uiViewController: SFSafariViewController,
+        context: UIViewControllerRepresentableContext<SafariView>
+    ) {
+        // no updates necessary
+    }
+}

--- a/Mlem/Views/Shared/Website Icon Complex.swift
+++ b/Mlem/Views/Shared/Website Icon Complex.swift
@@ -7,7 +7,6 @@
 
 import CachedAsyncImage
 import Foundation
-import SafariServices
 import SwiftUI
 
 struct WebsiteIconComplex: View
@@ -21,6 +20,8 @@ struct WebsiteIconComplex: View
     @State var post: Post
 
     @State private var overridenWebsiteFaviconName: String = "globe"
+    
+    @Environment(\.openURL) private var openURL
 
     var faviconURL: URL?
     {
@@ -151,11 +152,10 @@ struct WebsiteIconComplex: View
             }
         }
         .groupBoxStyle(OutlinedWebComplexStyle())
-        .onTapGesture
-        { /// Open in-app safari
-            let safariViewController = SFSafariViewController(url: post.url!, configuration: AppConstants.inAppSafariConfiguration)
-
-            UIApplication.shared.firstKeyWindow?.rootViewController?.present(safariViewController, animated: true)
+        .onTapGesture {
+            if let url = post.url {
+                openURL(url)
+            }
         }
     }
 }


### PR DESCRIPTION
This PR addresses the issue described [here](https://github.com/users/buresdv/projects/4/views/1?pane=issue&itemId=29858951).

I have updated things so that we stay in a `SwiftUI` context via a representable wrapper rather than interacting directly with `UIKit`.

Requests to open a URL by the application are now caught at the `ContentView` level, in the future we can pass any URL we want handled into the environment and the behaviour of modally presenting the `SafariView` should occur.

I've added a TODO as there should be some consideration made of how URLs which we can determine are linking to communities/posts etc should be handled, as a better UX would be for the user to be navigated within the application to our native views as opposed to treating all links as external.