### PR TITLE
fix - increase maximum message size

### DIFF
--- a/Mlem/Logic/Networking/Send Command.swift
+++ b/Mlem/Logic/Networking/Send Command.swift
@@ -24,6 +24,7 @@ func sendCommand(maintainOpenConnection: Bool, instanceAddress: URL, command: St
 
     let finalCommand = URLSessionWebSocketTask.Message.string(command)
     
+    task.maximumMessageSize = 1048576 * 2 // temporarily increased in lieu of REST migration
     task.resume()
     
     try await task.send(finalCommand)


### PR DESCRIPTION
As discussed [here](https://github.com/buresdv/Mlem/issues/13) the application crashes when attempting to load to many comments.

As the migration to REST is in progress this temporary fix will mitigate the crash win the short term until the web socket implementation is replaced.