### PR TITLE
fix #50 - avoid force unwrapping urls

### DIFF
--- a/Mlem/Logic/Networking/Get Correct URL to Endpoint.swift
+++ b/Mlem/Logic/Networking/Get Correct URL to Endpoint.swift
@@ -7,45 +7,34 @@
 
 import Foundation
 
-fileprivate enum EndpointDiscoveryError: Error
-{
+enum EndpointDiscoveryError: Error {
     case couldNotFindAnyCorrectEndpoints
 }
 
-func getCorrectURLtoEndpoint(baseInstanceAddress: String) async throws -> URL
-{
+func getCorrectURLtoEndpoint(baseInstanceAddress: String) async throws -> URL {
     var validAddress: URL?
     
-    let possibleInstanceAddresses: [URL] = [
-        URL(string: "https://\(baseInstanceAddress)/api/v1/user")!,
-        URL(string: "https://\(baseInstanceAddress)/api/v2/user")!,
-        URL(string: "https://\(baseInstanceAddress)/api/v3/user")!
+    let possibleInstanceAddresses = [
+        URL(string: "https://\(baseInstanceAddress)/api/v1/user"),
+        URL(string: "https://\(baseInstanceAddress)/api/v2/user"),
+        URL(string: "https://\(baseInstanceAddress)/api/v3/user")
     ]
+        .compactMap { $0 }
     
-    for address in possibleInstanceAddresses
-    {
-        if await checkIfEndpointExists(at: address)
-        {
+    for address in possibleInstanceAddresses {
+        if await checkIfEndpointExists(at: address) {
             print("\(address) is valid")
             validAddress = address.deletingLastPathComponent()
-            
-            print("Will use address \(validAddress)")
-            
             break
-        }
-        else
-        {
+        } else {
             print("\(address) is invalid")
             continue
         }
     }
     
-    if validAddress != nil
-    {
-        return validAddress!
+    if let validAddress {
+        return validAddress
     }
-    else
-    {
-        throw EndpointDiscoveryError.couldNotFindAnyCorrectEndpoints
-    }
+    
+    throw EndpointDiscoveryError.couldNotFindAnyCorrectEndpoints
 }

--- a/Mlem/Logic/Server Response Parsing/Comment Parser.swift
+++ b/Mlem/Logic/Server Response Parsing/Comment Parser.swift
@@ -129,7 +129,6 @@ private extension JSON {
             apID: self["comment", "ap_id"].url!,
             local: self["comment", "local"].boolValue,
             communityID: self["community", "id"].intValue,
-            communityActorID: self["community", "actor_id"].url!,
             communityLocal: self["community", "local"].boolValue,
             communityName: self["community", "name"].stringValue,
             communityIcon: self["community", "icon"].url,

--- a/Mlem/Models/User-Interactable/Comment.swift
+++ b/Mlem/Models/User-Interactable/Comment.swift
@@ -24,7 +24,6 @@ struct Comment: Codable, Identifiable, Hashable
     let apID: URL
     let local: Bool
     let communityID: Int
-    let communityActorID: URL
     let communityLocal: Bool
     let communityName: String
     let communityIcon: URL?

--- a/Mlem/Views/Shared/Website Icon Complex.swift
+++ b/Mlem/Views/Shared/Website Icon Complex.swift
@@ -22,16 +22,15 @@ struct WebsiteIconComplex: View
 
     @State private var overridenWebsiteFaviconName: String = "globe"
 
-    var faviconURL: URL?
-    {
-        if let baseURL = post.url?.host
-        {
-            return URL(string: "https://www.google.com/s2/favicons?sz=64&domain=\(baseURL)")!
-        }
-        else
-        {
+    var faviconURL: URL? {
+        guard
+            let baseURL = post.url?.host,
+            let imageURL = URL(string: "https://www.google.com/s2/favicons?sz=64&domain=\(baseURL)")
+        else {
             return nil
         }
+        
+        return imageURL
     }
 
     var body: some View


### PR DESCRIPTION
This PR addresses #50 

As noted in the above issue the crash reports highlight a runtime error:

`Unexpectedly found nil while unwrapping an Optional value`

The changes [here](https://github.com/buresdv/Mlem/compare/master...mormaer:fix-50-force_unwrap_url_crash?expand=1#diff-c58a875406d9325f1c6fc2c6497b428aa2a1fdb8d0ac6e48e5774e1bafd957acR18) remove the force unwrapping (`!`) on the URLs, if an invalid `baseInstanceAddresss` parameter is fed in we will now throw the error instead of crashing.

You can test this fix with the following steps:
- [ ] On the existing build enter an invalid address on the add account page, eg `beehaw   .org`, note the whitespace
- [ ] Enter credentials and tap log in
- [ ] Confirm the app crashes
- [ ] Build this branch and repeat the above steps
- [ ] Confirm you are shown the `unable to connect...` error message without crashing

---

Added two additional commits to address other crashes for force unwrapping in the logs.

Of the remaining issues that the logs identify:
- a few are low-level Swift errors which are difficult to resolve without steps to replicate
- one is in `convertResponseDateToDate` which appears to have been mitigated by previous changes, the reports appear to be from app version `0.0.2`
- one is linked to the current Safari view implementation which should be resolved by #46