### PR TITLE
fix #69 - avoid multiple `loadInfiniteFeed` calls

### DIFF
--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
@@ -151,37 +151,6 @@ struct CommunityView: View
                                     }
                                 }
                             }
-                            .onChange(of: selectedSortingOption, perform: { newValue in
-                                Task
-                                {
-                                    print("Selected sorting option: \(newValue), \(newValue.rawValue)")
-
-                                    postTracker.posts = .init()
-                                    postTracker.page = 1
-
-                                    if community == nil
-                                    {
-                                        
-                                        if postTracker.posts.isEmpty
-                                        {
-                                            postTracker.isLoading = true
-                                        }
-                                        
-                                        await loadInfiniteFeed(postTracker: postTracker, appState: appState, community: nil, feedType: feedType, sortingType: selectedSortingOption, account: account)
-                                        postTracker.isLoading = false
-                                    }
-                                    else
-                                    {
-                                        if postTracker.posts.isEmpty
-                                        {
-                                            postTracker.isLoading = true
-                                        }
-                                        
-                                        await loadInfiniteFeed(postTracker: postTracker, appState: appState, community: post.community, feedType: feedType, sortingType: selectedSortingOption, account: account)
-                                        postTracker.isLoading = false
-                                    }
-                                }
-                            })
                         }
                     }
                 }
@@ -398,7 +367,26 @@ struct CommunityView: View
                 {
                     if !isShowingCommunitySearch
                     {
-                        SortingMenu(selectedSortingOption: $selectedSortingOption)
+                        SortingMenu(selectedSortingOption: Binding(get: {
+                            selectedSortingOption
+                        }, set: { newValue in
+                            self.selectedSortingOption = newValue
+                            Task {
+                                print("Selected sorting option: \(newValue), \(newValue.rawValue)")
+                                
+                                postTracker.posts = .init()
+                                postTracker.page = 1
+                                
+                                
+                                if postTracker.posts.isEmpty {
+                                    postTracker.isLoading = true
+                                }
+                                
+                                await loadInfiniteFeed(postTracker: postTracker, appState: appState, community: community, feedType: feedType, sortingType: selectedSortingOption, account: account)
+                                postTracker.isLoading = false
+                                
+                            }
+                        }))
 
                         Menu
                         {

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sorting Menu.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Components/Sorting Menu.swift
@@ -14,63 +14,62 @@ struct SortingMenu: View {
     var body: some View {
         Menu
         {
-            Button
-            {
-                selectedSortingOption = .active
-            } label: {
-                Label("Active", systemImage: "bubble.left.and.bubble.right")
-            }
+            OptionButton(
+                title: "Active",
+                imageName: "bubble.left.and.bubble.right",
+                option: .active,
+                selectedOption: $selectedSortingOption
+            )
             
-            Button
-            {
-                selectedSortingOption = .hot
-            } label: {
-                Label("Hot", systemImage: "flame")
-            }
+            OptionButton(
+                title: "Hot",
+                imageName: "flame",
+                option: .hot,
+                selectedOption: $selectedSortingOption
+            )
+
+            OptionButton(
+                title: "New",
+                imageName: "sun.max",
+                option: .new,
+                selectedOption: $selectedSortingOption
+            )
             
-            Button
-            {
-                selectedSortingOption = .new
-            } label: {
-                Label("New", systemImage: "sun.max")
-            }
-            
-            Menu
-            {
-                Button
-                {
-                    selectedSortingOption = .topDay
-                } label: {
-                    Label("Day", systemImage: "calendar.day.timeline.left")
-                }
+            Menu {
+                OptionButton(
+                    title: "Day",
+                    imageName: "calendar.day.timeline.left",
+                    option: .topDay,
+                    selectedOption: $selectedSortingOption
+                )
+
+                OptionButton(
+                    title: "Week",
+                    imageName: "calendar.day.timeline.left",
+                    option: .topWeek,
+                    selectedOption: $selectedSortingOption
+                )
                 
-                Button
-                {
-                    selectedSortingOption = .topWeek
-                } label: {
-                    Label("Week", systemImage: "calendar.day.timeline.left")
-                }
-                
-                Button
-                {
-                    selectedSortingOption = .topMonth
-                } label: {
-                    Label("Month", systemImage: "calendar.day.timeline.left")
-                }
-                
-                Button
-                {
-                    selectedSortingOption = .topYear
-                } label: {
-                    Label("Year", systemImage: "calendar.day.timeline.left")
-                }
-                
-                Button
-                {
-                    selectedSortingOption = .topAll
-                } label: {
-                    Label("All time", systemImage: "calendar.day.timeline.left")
-                }
+                OptionButton(
+                    title: "Month",
+                    imageName: "calendar.day.timeline.left",
+                    option: .topMonth,
+                    selectedOption: $selectedSortingOption
+                )
+
+                OptionButton(
+                    title: "Year",
+                    imageName: "calendar.day.timeline.left",
+                    option: .topYear,
+                    selectedOption: $selectedSortingOption
+                )
+
+                OptionButton(
+                    title: "All time",
+                    imageName: "calendar.day.timeline.left",
+                    option: .topAll,
+                    selectedOption: $selectedSortingOption
+                )
             } label: {
                 Label("Top…", systemImage: "text.line.first.and.arrowtriangle.forward")
             }
@@ -93,11 +92,24 @@ struct SortingMenu: View {
                     Label("Selected sorting by \"Top of Year\"", systemImage: "calendar.day.timeline.left")
                 case .topAll:
                     Label("Selected sorting by \"Top of All Time\"", systemImage: "calendar.day.timeline.left")
-                    
-#warning("TODO: Make this the default icon for the sorting")
-                    /* case .unspecified:
-                     Label("Sort posts", systemImage: "arrow.up.and.down.text.horizontal") */
             }
         }
+    }
+}
+
+struct OptionButton<Option: Equatable>: View {
+    
+    let title: String
+    let imageName: String
+    let option: Option
+    @Binding var selectedOption: Option
+    
+    var body: some View {
+        Button {
+            selectedOption = option
+        } label: {
+            Label(title, systemImage: imageName)
+        }
+        .disabled(option == selectedOption)
     }
 }


### PR DESCRIPTION
This PR addresses the bug raised in #69 

While working on another branch (the API changes) I ran into this issue during testing, I have resolved it on that branch but thought it'd be worth a separate PR to resolve it in `master` rather than wait on that work wrapping up.

The issue was being caused by the `.onChange` behaviour in SwiftUI (shakes fist). When a user selected a new sorting option the callback to report the new value happens multiple times, as a result the existing logic would start loading the posts feed multiple times, which would result in duplicates being added to the `postTracker`.

The resolution is to use a manual `Binding` initialiser which only calls once on selection.

*Note: If you re-select the same feed type the behaviour now re-loads the feed, this could be avoided with a `guard` if we prefer, but this does mean if you're a few pages down your feed and re-select your option you're returned to page 1/top which may be desirable behaviour, if not let me know an I can add the `guard` to stop it*

You can confirm this fix with the following steps:
- [ ] Run the current `master` branch
- [ ] Navigate into the post feed
- [ ] Change to a sort option other than the default
- [ ] Begin scrolling down your feed
- [ ] Confirm you see the same posts repeat (if you are debugging in Xcode you'll see SwiftUI complaining about duplicate ids too)
- [ ] Build and run this branch
- [ ] Repeat the above steps
- [ ] Confirm the feed no longer repeats