### PR TITLE
Add lemmy docker compose

### DIFF
--- a/docker/Makefile
+++ b/docker/Makefile
@@ -1,0 +1,6 @@
+docker-start:
+	docker compose up -d
+docker-stop:
+	docker compose stop
+docker-remove:
+	docker compose down -v

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,0 +1,93 @@
+version: "3.3"
+
+name: mlem-dev
+
+networks:
+  # communication to web and clients
+  lemmyexternalproxy:
+  # communication between lemmy services
+  lemmyinternal:
+    driver: bridge
+    internal: true
+
+services:
+  proxy:
+    image: nginx:1-alpine
+    networks:
+      - lemmyinternal
+      - lemmyexternalproxy
+    ports:
+      # only ports facing any connection from outside
+      - 80:80 
+      - 443:443
+    volumes:
+      - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      # setup your certbot and letsencrypt config 
+      - ./certbot:/var/www/certbot
+      - ./letsencrypt:/etc/letsencrypt/live
+    restart: always
+    depends_on:
+      - pictrs
+      - lemmy-ui
+
+  lemmy:
+    image: dessalines/lemmy:0.17.3
+    hostname: lemmy
+    networks:
+      - lemmyinternal
+    restart: always
+    environment:
+      - RUST_LOG="warn,lemmy_server=info,lemmy_api=info,lemmy_api_common=info,lemmy_api_crud=info,lemmy_apub=info,lemmy_db_schema=info,lemmy_db_views=info,lemmy_db_views_actor=info,lemmy_db_views_moderator=info,lemmy_routes=info,lemmy_utils=info,lemmy_websocket=info"
+    volumes:
+      - ./lemmy.hjson:/config/config.hjson
+    depends_on:
+      - postgres
+      - pictrs
+
+  lemmy-ui:
+    image: dessalines/lemmy-ui:0.17.3
+    networks:
+      - lemmyinternal
+    environment:
+      # this needs to match the hostname defined in the lemmy service
+      - LEMMY_UI_LEMMY_INTERNAL_HOST=lemmy:8536
+      # set the outside hostname here
+      - LEMMY_UI_LEMMY_EXTERNAL_HOST=localhost:1236
+      - LEMMY_HTTPS=true
+    depends_on:
+      - lemmy
+    restart: always
+
+  pictrs:
+    image: asonix/pictrs:0.3.1
+    # this needs to match the pictrs url in lemmy.hjson
+    hostname: pictrs
+    # we can set options to pictrs like this, here we set max. image size and forced format for conversion
+    # entrypoint: /sbin/tini -- /usr/local/bin/pict-rs -p /mnt -m 4 --image-format webp
+    networks:
+      - lemmyinternal
+    environment:
+      - PICTRS__API_KEY=API_KEY
+    user: 991:991
+    volumes:
+      - pictrs:/mnt
+    restart: always
+
+  postgres:
+    image: postgres:15-alpine
+    # this needs to match the database host in lemmy.hson
+    hostname: postgres
+    networks:
+      - lemmyinternal
+    environment:
+      - POSTGRES_USER=lemmy
+      - POSTGRES_PASSWORD=password
+      - POSTGRES_DB=lemmy
+    volumes:
+      - postgres:/var/lib/postgresql/data
+    restart: always
+
+volumes:
+  postgres:
+  pictrs:
+  

--- a/docker/lemmy.hjson
+++ b/docker/lemmy.hjson
@@ -1,0 +1,46 @@
+{
+  # for more info about the config, check out the documentation
+  # https://join-lemmy.org/docs/en/administration/configuration.html
+  # only few config options are covered in this example config
+
+  setup: {
+    # username for the admin user
+    admin_username: "lemmy"
+    # password for the admin user
+    admin_password: "lemmylemmy"
+    # name of the site (can be changed later)
+    site_name: "mylemmyinstance"
+  }
+
+  # the domain name of your instance (eg "lemmy.ml")
+  hostname: "mydomain.ml"
+  # address where lemmy should listen for incoming requests
+  bind: "0.0.0.0"
+  # port where lemmy should listen for incoming requests
+  port: 8536
+  # Whether the site is available over TLS. Needs to be true for federation to work.
+  tls_enabled: true
+
+  # pictrs host
+  pictrs: {
+    url: "http://pictrs:8080/"
+    # api_key: "API_KEY"
+  }
+
+  # settings related to the postgresql database
+  database: {
+    # name of the postgres database for lemmy
+    database: "lemmy"
+    # username to connect to postgres
+    user: "lemmy"
+    # password to connect to postgres
+    password: "password"
+    # host where postgres is running
+    host: "postgres"
+    # port where postgres can be accessed
+    port: 5432
+    # maximum number of active sql connections
+    pool_size: 5
+  }
+}
+

--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -1,0 +1,71 @@
+worker_processes 1;
+events {
+    worker_connections 1024;
+}
+http {
+    upstream lemmy {
+        # this needs to map to the lemmy (server) docker service hostname
+        server "lemmy:8536";
+    }
+    upstream lemmy-ui {
+        # this needs to map to the lemmy-ui docker service hostname
+        server "lemmy-ui:1234";
+    }
+
+    server {
+        # this is the port inside docker, not the public one yet
+        listen 80;
+        # change if needed, this is facing the public web
+        server_name localhost;
+        server_tokens off;
+
+        gzip on;
+        gzip_types text/css application/javascript image/svg+xml;
+        gzip_vary on;
+
+        # Upload limit, relevant for pictrs
+        client_max_body_size 20M;
+
+        add_header X-Frame-Options SAMEORIGIN;
+        add_header X-Content-Type-Options nosniff;
+        add_header X-XSS-Protection "1; mode=block";
+
+        # frontend general requests
+        location / {
+            # distinguish between ui requests and backend
+            # don't change lemmy-ui or lemmy here, they refer to the upstream definitions on top
+            set $proxpass "http://lemmy-ui";
+
+            if ($http_accept = "application/activity+json") {
+              set $proxpass "http://lemmy";
+            }
+            if ($http_accept = "application/ld+json; profile=\"https://www.w3.org/ns/activitystreams\"") {
+              set $proxpass "http://lemmy";
+            }
+            if ($request_method = POST) {
+              set $proxpass "http://lemmy";
+            }
+            proxy_pass $proxpass;
+
+            rewrite ^(.+)/+$ $1 permanent;
+            # Send actual client IP upstream
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+
+        # backend
+        location ~ ^/(api|pictrs|feeds|nodeinfo|.well-known) {
+            proxy_pass "http://lemmy";
+            # proxy common stuff
+            proxy_http_version 1.1;
+            proxy_set_header Upgrade $http_upgrade;
+            proxy_set_header Connection "upgrade";
+
+            # Send actual client IP upstream
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header Host $host;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        }
+    }
+}


### PR DESCRIPTION
I followed the docker installation documentation
https://join-lemmy.org/docs/en/administration/install_docker.html

A simple `make docker-start` will start a lemmy server to test mlem on.

`make docker-remove` will remove all attributed containers and volumes