### PR TITLE
Fix #68 - crash when clicking community links

### DIFF
--- a/Mlem/ContentView.swift
+++ b/Mlem/ContentView.swift
@@ -12,6 +12,8 @@ struct ContentView: View
     
     @EnvironmentObject var appState: AppState
     
+    @State private var errorAlert: ErrorAlert?
+    
     var body: some View
     {
         TabView
@@ -45,6 +47,29 @@ struct ContentView: View
         {
             AppConstants.keychain["test"] = "I-am-a-saved-thing"
         }
-        .environment(\.openURL, OpenURLAction(handler: URLHandler.handle))
+        .alert(using: $errorAlert) { content in
+            Alert(title: Text(content.title), message: Text(content.message))
+        }
+        .environment(\.openURL, OpenURLAction(handler: didReceiveURL))
+    }
+}
+
+// MARK: - URL Handling
+
+extension ContentView {
+    func didReceiveURL(_ url: URL) -> OpenURLAction.Result {
+        let outcome = URLHandler.handle(url)
+        
+        switch outcome.action {
+        case let .error(message):
+            errorAlert = .init(
+                title: "Unsupported link",
+                message: message
+            )
+        default:
+            break
+        }
+        
+        return outcome.result
     }
 }

--- a/Mlem/Logic/URLHandler.swift
+++ b/Mlem/Logic/URLHandler.swift
@@ -29,6 +29,7 @@ class URLHandler {
     /// - Returns: A `Result` containing to the system level `OpenURLAction.Result` and any application level actions to perform
     static func handle(_ url: URL) -> Result {
         guard let scheme = url.scheme, scheme.hasPrefix("http") else {
+            // TODO: handle additional link types appropriately
             // as the current handling only supports http(s) via Safari bail early if the scheme is unsupported...
             // a future piece of work will add deep linking where possible with help of the `ResolveObject` API call
             return .init(result: .discarded, action: .error("This type of link is not currently supported 😞"))

--- a/Mlem/Logic/URLHandler.swift
+++ b/Mlem/Logic/URLHandler.swift
@@ -15,7 +15,12 @@ class URLHandler {
     init() { /* class should not be instantiated */ }
     
     static func handle(_ url: URL) -> OpenURLAction.Result {
-        #warning("TODO: consider how we might deep link within the application for urls such as '/c/<community_name>' and '/post/<post_id>'")
+        guard let scheme = url.scheme, scheme.hasPrefix("http") else {
+            // as the current handling only supports http(s) via Safari bail early if the scheme is unsupported...
+            // a future piece of work will add deep linking where posssible with help of the ResolveObject API call
+            return .discarded
+        }
+        
         let viewController = SFSafariViewController(url: url, configuration: .default)
         UIApplication.shared.firstKeyWindow?.rootViewController?.present(viewController, animated: true)
         return .handled

--- a/Mlem/Logic/URLHandler.swift
+++ b/Mlem/Logic/URLHandler.swift
@@ -11,19 +11,33 @@ import SafariServices
 /// A class that provides handling behaviour for `URL` actions
 class URLHandler {
     
+    /// The type of action to perform in response to the URL
+    enum Action {
+        case error(String)
+    }
+    
+    struct Result {
+        let result: OpenURLAction.Result
+        let action: Action?
+    }
+    
     @available(*, unavailable, message: "This handler should not be instantiated, please use static methods.")
     init() { /* class should not be instantiated */ }
     
-    static func handle(_ url: URL) -> OpenURLAction.Result {
+    /// A method to perform handling on URLs within the application
+    /// - Parameter url: The `URL` you require to be handled
+    /// - Returns: A `Result` containing to the system level `OpenURLAction.Result` and any application level actions to perform
+    static func handle(_ url: URL) -> Result {
         guard let scheme = url.scheme, scheme.hasPrefix("http") else {
             // as the current handling only supports http(s) via Safari bail early if the scheme is unsupported...
-            // a future piece of work will add deep linking where posssible with help of the ResolveObject API call
-            return .discarded
+            // a future piece of work will add deep linking where possible with help of the `ResolveObject` API call
+            return .init(result: .discarded, action: .error("This type of link is not currently supported 😞"))
         }
         
+        // TODO: as part of the deep linking work we'd ideally move this to remain in a `SwiftUI` context...
         let viewController = SFSafariViewController(url: url, configuration: .default)
         UIApplication.shared.firstKeyWindow?.rootViewController?.present(viewController, animated: true)
-        return .handled
+        return .init(result: .handled, action: nil)
     }
 }
 


### PR DESCRIPTION
# Checklist
- [x] I have described what this PR contains

**Choose one of the following two options:**
- - [x] This PR does not introduce major changes
- - [ ] This PR introduces major changes, and I have consulted @buresdv, @jboi or @mormaer in the *Mlem Development Matrix room*

**Choose one of the following two options:**
- - [ ] This PR does not change the UI in any way
- - [x] This PR adds new UI elements / changes the UI, and I have attached pictures or videos of the new / changed UI elements

# Pull Request Information

## About this Pull Request
This PR addresses the crash described in #68. The application was crashing as links in the style `!abc.def.ghi` are picked up by the `MarkdownView` as `mailto:abc@def.ghi`, we'd then attempt to feed this directly into Safari which Apple don't like 🙈.

As a first step this PR adds a small `guard` to ensure the URL is of the http/https protocol before proceeding with pushing Safari, any links that are not in that format will be `.discarded` and a generic alert will be presented to the user.

## Next steps

This PR resolves the crash however we want to get to a place where links are either handled natively in the application, or handed out to the OS/Safari.

The plan is to address #29 next to move to the new navigation APIs, and then #144 to correctly recognise links.

After which we should be unblocked for implementing deep linking by using the `resolve_object` API call to retrieve the corresponding community/post/user objects we need to display the content within the application.

## Considerations

One thing to note is that genuine `mailto:` links will now also display this alert for now, but I don't consider this a _regression_ as they would have crashed the application before this change. 🤷 

Another approach we could have would be that instead of discarding unsupported links we return `.systemAction`. This would open the users email client should they click an email link, but due to links in the format `!abc@def.ghi` being incorrectly parsed as `mailto:` currently we'd do the same 😞.

At present I think considering them unsupported is the best approach in lieu of the future work to correctly handle all links.

## Screenshots and Videos
| ALERT |
| --- |
| ![alert](https://github.com/buresdv/Mlem/assets/5231793/2eee2610-50e9-4d00-85ac-68cc4e20dcb2) |


## Additional Context
**Any additional context you'd like to add to help us review this PR**
