### PR TITLE
Added simple subscriptions list to the search window

### DIFF
--- a/Mlem/API/Requests/Community/ListCommunities.swift
+++ b/Mlem/API/Requests/Community/ListCommunities.swift
@@ -31,6 +31,7 @@ struct ListCommunitiesRequest: APIGetRequest {
 
             .init(name: "limit", value: limit.map(String.init)),
             .init(name: "page", value: page.map(String.init)),
+            .init(name: "type_", value: type.rawValue),
 
             .init(name: "auth", value: account.accessToken),
         ]
@@ -52,6 +53,7 @@ struct ListCommunitiesRequest: APIGetRequest {
 
             .init(name: "limit", value: limit.map(String.init)),
             .init(name: "page", value: page.map(String.init)),
+            .init(name: "type_", value: type.rawValue),
         ]
     }
 }

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community Search/Community Search View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community Search/Community Search View.swift
@@ -13,6 +13,7 @@ struct CommunitySearchResultsView: View
     @EnvironmentObject var communitySearchResultsTracker: CommunitySearchResultsTracker
 
     @State var searchResults: [Community]?
+    @State var subscribedCommunities: [APICommunity]?
 
     var account: SavedAccount
     var community: APICommunity?
@@ -99,6 +100,37 @@ struct CommunitySearchResultsView: View
                     } header: {
                         Text("Favorites")
                     }
+                    
+                    Section
+                    {
+                        if subscribedCommunities != nil {
+                            if !subscribedCommunities!.isEmpty
+                            {
+                                ForEach(subscribedCommunities!)
+                                { subscribedCommunity in
+                                    NavigationLink(destination: CommunityView(account: account, community: subscribedCommunity, feedType: .all))
+                                    {
+                                        Text("\(subscribedCommunity.name)\(Text("@\(subscribedCommunity.actorId.host!)").foregroundColor(.secondary).font(.caption))")
+                                            .swipeActions(edge: .trailing, allowsFullSwipe: true)
+                                        {
+                                        }
+                                    }
+                                }
+                            }
+                        }
+                        else
+                        {
+                            VStack(alignment: .center, spacing: 10)
+                            {
+                                Image(systemName: "star.slash")
+                                Text("You have no community subscriptions")
+                            }
+                            .listRowBackground(Color.clear)
+                            .frame(maxWidth: .infinity)
+                        }
+                    } header: {
+                        Text("Subscriptions")
+                    }
                 }
                 else
                 {
@@ -140,6 +172,19 @@ struct CommunitySearchResultsView: View
             }
         }
         .frame(height: 300)
+        .task {
+            let request = ListCommunitiesRequest(account: account, sort: nil, page: nil, limit: nil, type: FeedType.subscribed);
+            do {
+                let response = try await APIClient().perform(request: request);
+                subscribedCommunities = response.communities.map({
+                    return $0.community;
+                }).sorted(by: {
+                    $0.name < $1.name
+                });
+            } catch {
+                
+            }
+        }
     }
 
     internal func getFavoritedCommunitiesForAccount(account: SavedAccount, tracker: FavoriteCommunitiesTracker) -> [FavoriteCommunity]


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

Apologizes for the last PR, I hit submit too soon!

# Checklist
- [x] I have described what this PR contains

**Choose one of the following two options:**
- - [x] This PR does not introduce major changes
- - [ ] This PR introduces major changes, and I have consulted @buresdv, @jboi or @mormaer in the *Mlem Development Matrix room*

**Choose one of the following two options:**
- - [ ] This PR does not change the UI in any way
- - [x] This PR adds new UI elements / changes the UI, and I have attached pictures or videos of the new / changed UI elements

# Pull Request Information

## About this Pull Request

This is just a draft, as I am a total Swift script kiddie.

This PR adds a section below "Favorites" which shows all of the communities you have subscribed to.  It's visually rough around the edges, but perhaps I'll get around to filling it out a little bit more.

This is a feature I really missed from Apollo so this is the first draft!

## Screenshots and Videos
![ezgif-2-f54b210f34](https://github.com/buresdv/Mlem/assets/1000311/d60f8c06-c001-4f8b-a725-1023bc2562ce)


## Additional Context
The main changes are:
- Updating the community search view with a new section + async task to fetch the subscriptions (this could probably be cached)
- Update the list communities request to fill in the "type" field that is already provided in the struct.
