### PR TITLE
Remove useless preferences

### DIFF
--- a/Mlem/Settings.bundle/Root.plist
+++ b/Mlem/Settings.bundle/Root.plist
@@ -4,58 +4,5 @@
 <dict>
 	<key>StringsTable</key>
 	<string>Root</string>
-	<key>PreferenceSpecifiers</key>
-	<array>
-		<dict>
-			<key>Type</key>
-			<string>PSGroupSpecifier</string>
-			<key>Title</key>
-			<string>Group</string>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSTextFieldSpecifier</string>
-			<key>Title</key>
-			<string>Name</string>
-			<key>Key</key>
-			<string>name_preference</string>
-			<key>DefaultValue</key>
-			<string></string>
-			<key>IsSecure</key>
-			<false/>
-			<key>KeyboardType</key>
-			<string>Alphabet</string>
-			<key>AutocapitalizationType</key>
-			<string>None</string>
-			<key>AutocorrectionType</key>
-			<string>No</string>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSToggleSwitchSpecifier</string>
-			<key>Title</key>
-			<string>Enabled</string>
-			<key>Key</key>
-			<string>enabled_preference</string>
-			<key>DefaultValue</key>
-			<true/>
-		</dict>
-		<dict>
-			<key>Type</key>
-			<string>PSSliderSpecifier</string>
-			<key>Key</key>
-			<string>slider_preference</string>
-			<key>DefaultValue</key>
-			<real>0.5</real>
-			<key>MinimumValue</key>
-			<integer>0</integer>
-			<key>MaximumValue</key>
-			<integer>1</integer>
-			<key>MinimumValueImage</key>
-			<string></string>
-			<key>MaximumValueImage</key>
-			<string></string>
-		</dict>
-	</array>
 </dict>
 </plist>


### PR DESCRIPTION
Closes #190 

# Checklist
- [X] I have described what this PR contains

**Choose one of the following two options:**
- - [X] This PR does not introduce major changes
- - [ ] This PR introduces major changes, and I have consulted @buresdv, @jboi or @mormaer in the *Mlem Development Matrix room*

**Choose one of the following two options:**
- - [X] This PR does not change the UI in any way
- - [ ] This PR adds new UI elements / changes the UI, and I have attached pictures or videos of the new / changed UI elements

# Pull Request Information

## About this Pull Request
This PR removes useless preferences that are not used in the app.

## Screenshots and Videos
Before:

![Simulator Screenshot - iPhone 14 Pro - 2023-06-18 at 15 57 38](https://github.com/buresdv/Mlem/assets/183264/1421258d-8631-4e3b-9847-fe099972da14)

After:

![Simulator Screenshot - iPhone 14 Pro - 2023-06-18 at 15 56 57](https://github.com/buresdv/Mlem/assets/183264/0dc12b00-ad07-4b93-93f1-c01c50ea6d64)