### PR TITLE
fix #191 - ensure 'dirty' state always resets after voting

### DIFF
--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Post Interaction Bar.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Post Item/Components/Post Interaction Bar.swift
@@ -119,54 +119,52 @@ struct PostInteractionBar: View {
     
     func upvote() async -> Void {
         // don't do anything if currently awaiting a vote response
-        guard dirty else {
-            // fake downvote
-            switch (displayedVote) {
-            case .upvote:
-                dirtyVote = .resetVote
-                dirtyScore = displayedScore - 1
-            case .resetVote:
-                dirtyVote = .upvote
-                dirtyScore = displayedScore + 1
-            case .downvote:
-                dirtyVote = .upvote
-                dirtyScore = displayedScore + 2
-            }
-            dirty = true
-            
-            // wait for vote
-            await voteOnPost(.upvote)
-            
-            // unfake downvote
-            dirty = false
+        guard !dirty else {
             return
         }
+        
+        defer { dirty = false }
+        
+        // fake downvote
+        switch (displayedVote) {
+        case .upvote:
+            dirtyVote = .resetVote
+            dirtyScore = displayedScore - 1
+        case .resetVote:
+            dirtyVote = .upvote
+            dirtyScore = displayedScore + 1
+        case .downvote:
+            dirtyVote = .upvote
+            dirtyScore = displayedScore + 2
+        }
+        
+        dirty = true
+        await voteOnPost(.upvote)
     }
     
     func downvote() async -> Void {
         // don't do anything if currently awaiting a vote response
-        guard dirty else {
-            // fake upvote
-            switch (displayedVote) {
-            case .upvote:
-                dirtyVote = .downvote
-                dirtyScore = displayedScore - 2
-            case .resetVote:
-                dirtyVote = .downvote
-                dirtyScore = displayedScore - 1
-            case .downvote:
-                dirtyVote = .resetVote
-                dirtyScore = displayedScore + 1
-            }
-            dirty = true
-            
-            // wait for vote
-            await voteOnPost(.downvote)
-            
-            // unfake upvote
-            dirty = false
+        guard !dirty else {
             return
         }
+        
+        defer { dirty = false }
+        
+        // fake upvote
+        switch (displayedVote) {
+        case .upvote:
+            dirtyVote = .downvote
+            dirtyScore = displayedScore - 2
+        case .resetVote:
+            dirtyVote = .downvote
+            dirtyScore = displayedScore - 1
+        case .downvote:
+            dirtyVote = .resetVote
+            dirtyScore = displayedScore + 1
+        }
+        
+        dirty = true
+        await voteOnPost(.downvote)
     }
     
     /**


### PR DESCRIPTION
# Checklist
- [x] I have described what this PR contains

**Choose one of the following two options:**
- - [x] This PR does not introduce major changes
- - [ ] This PR introduces major changes, and I have consulted @buresdv, @jboi or @mormaer in the *Mlem Development Matrix room*

**Choose one of the following two options:**
- - [x] This PR does not change the UI in any way
- - [ ] This PR adds new UI elements / changes the UI, and I have attached pictures or videos of the new / changed UI elements

# Pull Request Information

## About this Pull Request
Another small PR to fix the issue raised in #191.

## Additional Context
As mentioned in the attached issue there is a plan to refactor how these _fake_ votes are done so that both posts and comments use a single abstraction/protocol for easier maintenance going forward, however given that may not appear in the immediate future I thought it was worth fixing this issue now.
