### PR TITLE
Remember selected sorting options

### DIFF
--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
@@ -36,7 +36,7 @@ struct CommunityView: View
 
     @FocusState var isSearchFieldFocused: Bool
 
-    @State var feedType: FeedType = .subscribed
+    @AppStorage("selectedFeedType") var feedType: FeedType = .subscribed
 
     @State private var isComposingPost: Bool = false
     @State private var newPostTitle: String = ""

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
@@ -25,7 +25,7 @@ struct CommunityView: View
     @State var community: APICommunity?
     @State var communityDetails: GetCommunityResponse?
 
-    @State private var selectedSortingOption: SortingOptions = .hot
+    @AppStorage("selectedSortingOption") private var selectedSortingOption: SortingOptions = .hot
 
     @State private var isSidebarShown: Bool = false
     @State private var isShowingCommunitySearch: Bool = false


### PR DESCRIPTION
# Checklist
- [X] I have described what this PR contains

**Choose one of the following two options:**
- - [X] This PR does not introduce major changes
- - [ ] This PR introduces major changes, and I have consulted @buresdv, @jboi or @mormaer in the *Mlem Development Matrix room*

**Choose one of the following two options:**
- - [X] This PR does not change the UI in any way
- - [ ] This PR adds new UI elements / changes the UI, and I have attached pictures or videos of the new / changed UI elements

# Pull Request Information

## About this Pull Request
This is a simple change to persist across app launches, using AppStorage:

- the currently selected `SortingOptions` for the feed and 
- the currently selected `FeedType` (All Posts, Subscribed, etc)

Before this PR, each app launch will result in the feed resetting to the default Subscribed feed sorted by Hot. After this PR, the app will remember your last selected `FeedType` and `SortingOptions`.

## Screenshots and Videos
There are no UI changes, it's completely transparent to the user.

## Additional Context
This change was inspired by the last few days of using Mlem. As a new Lemmy user who hasn't subscribed to many communities, I prefer to browse the All Posts feed. The default Hot sort is not very useful in this case, as the content is essentially unchanged for the last several days. Remembering my last selected `FeedType` and `SortingOptions` lets me get right into the app and start browsing.

I considered adding a sort preference in Settings (to match the Default Comment Sort option that already exists). However I hesitate to add two different UIs for a single preference; it seems to me that allowing the user to pick their preferred sort _in context_ makes a lot of sense, and it's reasonable to expect that the app would remember this preference. Happy to adjust the implementation if an explicit setting is preferred.

Similar for FeedType -- it just makes sense that the app would remember which feed you browse.

A note on NSUserDefault keys: it may be useful to consider scoping the preferences a bit more specifically. For example in the future it may be best to persist sort options (for example) for each applicable screen; user feeds may have a different preferred sort than the post feed. Or taking it a step further, users may expect All Posts to sort differently than Subscribed or Local feeds.