### PR TITLE
Handle URLError.cancelled when scrolling quickly

### DIFF
--- a/Mlem/API/APIClient.swift
+++ b/Mlem/API/APIClient.swift
@@ -16,6 +16,7 @@ enum APIClientError: Error {
     case encoding(Error)
     case networking(Error)
     case response(APIErrorResponse, Int?)
+    case cancelled
 }
 
 class APIClient {
@@ -48,7 +49,11 @@ class APIClient {
         do {
             return try await session.data(for: urlRequest)
         } catch {
-            throw APIClientError.networking(error)
+            if case URLError.cancelled = error as NSError {
+                throw APIClientError.cancelled
+            } else {
+                throw APIClientError.networking(error)
+            }
         }
     }
     

--- a/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
+++ b/Mlem/Views/Tabs/Posts/Components/Post/Components/Community View/Community View.swift
@@ -496,6 +496,8 @@ struct CommunityView: View
                 title: "Error",
                 message: message.error
             )
+        } catch APIClientError.cancelled {
+            print("Failed while loading feed (request cancelled)")
         } catch {
             errorAlert = .unexpected
         }


### PR DESCRIPTION
<!-- 
Thank you for making a pull request! 
Since we are very busy with getting Mlem into a releaseable state, we had to introduce this short questionnaire to help us review PRs.
Before you submit your PR, please take a few minutes to fill out all the needed information.

Please note that if you do not fill out the checklist, your PR will be automatically rejected unless you are an approved contributor. 
We apologize, as we would love to dedicate the time it deserves to every PR, but at present, we are under considerable time pressure.
-->

# Checklist
- [X] I have described what this PR contains

**Choose one of the following two options:**
- - [X] This PR does not introduce major changes
- - [ ] This PR introduces major changes, and I have consulted @buresdv, @jboi or @mormaer in the *Mlem Development Matrix room*

**Choose one of the following two options:**
- - [X] This PR does not change the UI in any way
- - [ ] This PR adds new UI elements / changes the UI, and I have attached pictures or videos of the new / changed UI elements

# Pull Request Information

## About this Pull Request
This PR suppresses an unnecessary network error which occurs when a feed load URL request is cancelled. This is probably not related to #181 but may be adding confusion.

To reproduce the error, just scroll quickly through a feed - you'll get a modal error dialog ("Unable to connect to Lemmy"). The app will function as expected otherwise, and the next page will load normally despite the error message.

It can also occur when a feed load request is slow to finish and the user is impatient; scrolling down again will trigger a new reload and cancel the previous, triggering the error dialog.

This is expected behavior when using SwiftUIs Task modifier for network requests.

Note that this PR will suppress **all** cancellation errors for feed loads. I don't consider this a major change since cancellations should not usually occur otherwise.

## Screenshots and Videos
There are no UI changes. Attached is an image of the error:
![image](https://github.com/buresdv/Mlem/assets/7362344/779e2f88-0e56-400f-b824-191bff11ec7b)

## Additional Context
This error is caused by SwiftUIs Task modifier which Mlem uses to load the next page in the feed, when the final post appears onscreen. It's expected that the Task [will match the lifetime of the View](https://developer.apple.com/documentation/swiftui/view/task(priority:_:)) it's attached to, so automatic cancellation is normal.

By scrolling down while the feed load is already in progress (taking the view offscreen momentarily), it's possible to trigger the View's appearance multiple times. This will always trigger a cancelation of the previous request, and cause a new request to fire.

This error _could_ be eliminated by queueing the requests, or by adding a simple lock, but that may not be the desired behavior. For example, if a request has stalled the user may actually wish to trigger a new one by scrolling down a second time; in this example the cancellation is the desired outcome, and the error message is unnecessary.